### PR TITLE
Feature/support escaped characters

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!--Versions-->
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<!--https://github.com/apache/tika/blob/main/CHANGES.txt -->
 		<apache.tika.version>2.9.1</apache.tika.version>
 		<!--https://github.com/atteo/classindex/tags -->

--- a/src/main/java/de/webalf/slotbot/util/DiscordMarkdown.java
+++ b/src/main/java/de/webalf/slotbot/util/DiscordMarkdown.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  */
 @UtilityClass
 public final class DiscordMarkdown {
+
     private static final Map<Pattern, HTML_TAG> MARKDOWN_TO_HTML_TAG_MAPPINGS = new LinkedHashMap<>();
     private static final Safelist SAFELIST = Safelist.none();
 
@@ -29,16 +30,17 @@ public final class DiscordMarkdown {
         // The order matters (hence a LinkedHashMap).
         // Markdown formatting that consists of multiple characters (eg. __underline__) needs to be processed
         // before formatting that consists of lesser characters (eg. _italic_).
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^#{3}\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_3);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^#{2}\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_2);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^#\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_1);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^(?<!\\\\)#{3}\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_3);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^(?<!\\\\)#{2}\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_2);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?m)^(?<!\\\\)#\\s(?<content>.+?)(\n|$)"), HTML_TAG.HTML_HEADING_1);
         MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("\n"), HTML_TAG.HTML_BREAK);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("\\*{3}(?<content>.+?)\\*{3}"), HTML_TAG.HTML_STRONG_ITALIC);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("\\*{2}(?<content>.+?)\\*{2}"), HTML_TAG.HTML_STRONG);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("_{2}(?<content>.+?)_{2}"), HTML_TAG.HTML_UNDERLINE);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("~{2}(?<content>.+?)~{2}"), HTML_TAG.HTML_STRIKETHROUGH);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("\\*(?<content>.+?)\\*"), HTML_TAG.HTML_ITALIC);
-        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("_(?<content>.+?)_"), HTML_TAG.HTML_ITALIC);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)\\*{3}(?<content>.+?)\\*{3}"), HTML_TAG.HTML_STRONG_ITALIC);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)\\*{2}(?<content>.+?)\\*{2}"), HTML_TAG.HTML_STRONG);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)_{2}(?<content>.+?)_{2}"), HTML_TAG.HTML_UNDERLINE);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)~{2}(?<content>.+?)~{2}"), HTML_TAG.HTML_STRIKETHROUGH);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)\\*(?<content>.+?)\\*"), HTML_TAG.HTML_ITALIC);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("(?<!\\\\)_(?<content>.+?)_"), HTML_TAG.HTML_ITALIC);
+        MARKDOWN_TO_HTML_TAG_MAPPINGS.put(Pattern.compile("\\\\(?<content>[*_`~\\\\])"), HTML_TAG.NOTHING);
 
         SAFELIST.addTags("br", "s", "u", "strong", "em", "h1", "h2", "h3");
     }
@@ -61,6 +63,10 @@ public final class DiscordMarkdown {
                         String content = "";
                         try {
                             content = matchResult.group("content");
+                            // Funnily enough, if the escape character (backslash) is matched, we need to escape it again, otherwise replacing it will not work
+                            if ("\\".equals(content)) {
+                                content = "\\\\";
+                            }
                         } catch (IllegalArgumentException e) {
                             // Do nothing, this is fine, group "content" does not exist
                         }
@@ -84,7 +90,8 @@ public final class DiscordMarkdown {
         HTML_STRONG_ITALIC("<strong><em>", "</strong></em>"),
         HTML_HEADING_1("<h1>", "</h1>"),
         HTML_HEADING_2("<h2>", "</h2>"),
-        HTML_HEADING_3("<h3>", "</h3>");
+        HTML_HEADING_3("<h3>", "</h3>"),
+        NOTHING("", null);
 
         @Getter
         private final String openingTag;

--- a/src/main/java/de/webalf/slotbot/util/DiscordMarkdown.java
+++ b/src/main/java/de/webalf/slotbot/util/DiscordMarkdown.java
@@ -60,18 +60,18 @@ public final class DiscordMarkdown {
         MARKDOWN_TO_HTML_TAG_MAPPINGS.forEach((pattern, htmlTag) -> {
             Matcher matcher = pattern.matcher(result.get());
             result.set(matcher.replaceAll(matchResult -> {
-                        String content = "";
+                        Optional<String> content = Optional.empty();
                         try {
-                            content = matchResult.group("content");
+                            content = Optional.ofNullable(matchResult.group("content"));
                             // Funnily enough, if the escape character (backslash) is matched, we need to escape it again, otherwise replacing it will not work
-                            if ("\\".equals(content)) {
-                                content = "\\\\";
+                            if (content.isPresent() && "\\".equals(content.get())) {
+                                content = Optional.of("\\\\");
                             }
                         } catch (IllegalArgumentException e) {
                             // Do nothing, this is fine, group "content" does not exist
                         }
                         return htmlTag.getOpeningTag() +
-                                content +
+                                content.orElse("") +
                                 htmlTag.getClosingTag()
                                         .orElse("");
                     }

--- a/src/test/java/de/webalf/slotbot/util/DiscordMarkdownTest.java
+++ b/src/test/java/de/webalf/slotbot/util/DiscordMarkdownTest.java
@@ -56,7 +56,10 @@ class DiscordMarkdownTest {
 						h3""", "<h1>Heading 1</h1>h1%1$s<h2>Heading 2</h2>h2%1$s%2$s\n<h3>Heading 3</h3>h3".formatted(FORMATTED_BREAK, HTML_BREAK), "headings"),
 				Arguments.of("Text # Hello World", "Text # Hello World", "inline heading"),
 				Arguments.of("Evil <script>alert('Hello World');</script> <a href=\"https://example.com\">Link</a>",
-						"Evil  Link", "filters other html tags")
+						"Evil  Link", "filters other html tags"),
+				Arguments.of("\\*Lorem\\* \\_ipsum\\_ \\`dolor\\` \\~sit\\~ \\\\amet\\\\",
+						"*Lorem* _ipsum_ `dolor` ~sit~ \\amet\\",
+						"unescape escaped characters")
 		);
 	}
 }


### PR DESCRIPTION
Diese PR fügt Support für in Discord escapede characters hinzu. Was in Discord Markdown mit einem Backslash escaped wurde, wird beim Konvertieren nach HTML ignoriert. Die Backslashes werden in dem fertigen HTML dann entfernt. 

Damit sollte das hier kein Problem mehr sein:
![image](https://github.com/Alf-Melmac/slotbotServer/assets/7814881/77f2b10f-9f40-4ff8-aac0-27d71470c9c8)

Die Logik für das Konvertieren von Discord Markdown nach HTML wurde dafür komplett refactored. Da Methoden benutzt werden, die mit Java 20 erst eingeführt wurden ( https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/MatchResult.html#group(java.lang.String) ), wurde auch auf Java 21 LTS geupdated.

Dies muss noch mit einem echten Discord-Server vertestet werden, da ich das lokale Setup nicht aufgesetzt habe und nur anhand der Unit-Tests entwickeln konnte. Bei Fragen gerne auf dem TTT-Discord bei mir melden.